### PR TITLE
feat(ci): Add publish workflow to Github.

### DIFF
--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -1,0 +1,36 @@
+name: Upload to PyPi
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    name: Publish release to PyPi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/py-wsvnc
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build the package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
New PR to replace old one that adds a PyPi upload workflow. 

This should be fine, I signed it with my ssh key and added that key to GitHub as a signature key.