### PR TITLE
fix: use NullHandler instead of logging.basicConfig

### DIFF
--- a/src/wsvnc/utils/logger.py
+++ b/src/wsvnc/utils/logger.py
@@ -1,7 +1,6 @@
 """Basic logger."""
 
 import logging
-import os
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -18,8 +17,6 @@ def get_logger(name: str) -> logging.Logger:
         A logger
     """
     logger = logging.getLogger(name)
-    logging.basicConfig(
-        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        level=os.environ.get("LOGLEVEL", "INFO"),
-    )
+    if not logger.handlers:
+        logger.addHandler(logging.NullHandler())
     return logger


### PR DESCRIPTION
`logging.basicConfig` adds additional handler, which might conflict with applications using the library.

Remove and replace to use `NullHandler` based on [library recommendations](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).

Co-authored-by: GitHub Copilot <copilot@github.com>
Agent-Logs-Url: https://github.com/SilverBut/py-wsvnc/sessions/abe9fc8a-b0f8-4b31-963c-a765c4b9762f